### PR TITLE
Release 1.1.1

### DIFF
--- a/HTMLWriter.cs
+++ b/HTMLWriter.cs
@@ -7,9 +7,9 @@ namespace HTMLWriterPackage
     public class HTMLWriter : ElementBuilder
     {
         //Properties
-        protected XmlWriter Body { get; set; }
+        private XmlWriter Body { get; set; }
 
-        protected XmlWriter Head { get; set; }
+        private XmlWriter Head { get; set; }
 
         //Constructor
         public HTMLWriter()


### PR DESCRIPTION
Patch update. Changing access modifiers on fields in HTMLWriter class.

These fields were moved from the parent class ElementBuilder to the derived class HTMLWriter. Changes to access modifiers were needed to retain encapsulation of the program.